### PR TITLE
Prevent objects copy

### DIFF
--- a/mental-noise-synapse/mental-noise-synapse.ino
+++ b/mental-noise-synapse/mental-noise-synapse.ino
@@ -76,20 +76,13 @@ const byte midiNotes[numberOfNotes] = {
 const byte defaultControlValue = 63;
 
 // CV Inputs pins.
-ResponsiveAnalogRead cc1(A7, true);
-ResponsiveAnalogRead cc2(A6, true);
-ResponsiveAnalogRead cc3(A5, true);
-ResponsiveAnalogRead cc4(A4, true);
-ResponsiveAnalogRead cc5(A3, true);
-ResponsiveAnalogRead cc6(A2, true);
-
-const ResponsiveAnalogRead ccInputs[numberOfControls] = {
-        cc1, // Clap PCM Speed
-        cc2, // Claves PCM Speed
-        cc3, // Agogo PCM Speed
-        cc4, // Crash PCM Speed
-        cc5, // Stutter Time
-        cc6, // Stutter Depth
+ResponsiveAnalogRead ccInputs[numberOfControls] = {
+    ResponsiveAnalogRead(A7, true), // Clap PCM Speed
+    ResponsiveAnalogRead(A6, true), // Clap PCM Speed
+    ResponsiveAnalogRead(A5, true), // Agogo PCM Speed
+    ResponsiveAnalogRead(A4, true), // Crash PCM Speed
+    ResponsiveAnalogRead(A3, true), // Stutter Time
+    ResponsiveAnalogRead(A2, true), // Stutter Depth
 };
 
 /*


### PR DESCRIPTION
That analog read class doesn't have its copy/assignment constructors deleted (which would be standard for embedded code), this causes redundant objects copying when storing them to array. We can save a few hundreds bytes of RAM and flash by avoiding this copy.

Also, const qualifier is ignored for those objects, because we call non-const methods on them. This gives warning if compiling with more modern GCC versions than what's used by avr-gcc (i.e. if building for STM32)